### PR TITLE
Add Gjensidige's designsystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ If you're missing one, please make a [pull request](https://github.com/siiron/no
 | [Finn - Fabric](https://www.fabric-ds.io/)                                     |     ✔️     |              |      ✔️       |      [Github](https://github.com/fabric-ds/)                  |
 | [FNSP](https://design.fnsp.no/#/intro)                                         |     ✔️     |              |                |                                                               |
 | [Fremtind - Jøkul](https://fremtind.github.io/jokul/)                          |     ✔️     |      ✔️      |      ✔️       |          [Github](https://github.com/fremtind/jokul)          |
-| [Gjensidige - Builders Core](https://gjensidige.builders/docs/core/)                          |     ✔️     |      ✔️      |      ✔️       |                    |
+| [Gjensidige - Builders Core](https://www.gjensidige.builders/docs/core/)                          |     ✔️     |      ✔️      |      ✔️       |                    |
 | [Helsenorge](https://helsenorge.design/)                                       |     ✔️     |              |                |     [Github](https://github.com/helsenorge/designsystem)      |
 | [If Design system ](https://design.if.eu/)                 |     ✔️     |              |                |                                                               |
 | [IMDi Designsystem ](https://www.imdi.no/om-imdi/designsystem/)                                    |     ✔️     |              |      ✔️       |                                                               |

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ If you're missing one, please make a [pull request](https://github.com/siiron/no
 | [Finn - Fabric](https://www.fabric-ds.io/)                                     |     ✔️     |              |      ✔️       |      [Github](https://github.com/fabric-ds/)                  |
 | [FNSP](https://design.fnsp.no/#/intro)                                         |     ✔️     |              |                |                                                               |
 | [Fremtind - Jøkul](https://fremtind.github.io/jokul/)                          |     ✔️     |      ✔️      |      ✔️       |          [Github](https://github.com/fremtind/jokul)          |
+| [Gjensidige - Builders Core](https://gjensidige.builders/docs/core/)                          |     ✔️     |      ✔️      |      ✔️       |                    |
 | [Helsenorge](https://helsenorge.design/)                                       |     ✔️     |              |                |     [Github](https://github.com/helsenorge/designsystem)      |
 | [If Design system ](https://design.if.eu/)                 |     ✔️     |              |                |                                                               |
 | [IMDi Designsystem ](https://www.imdi.no/om-imdi/designsystem/)                                    |     ✔️     |              |      ✔️       |                                                               |


### PR DESCRIPTION
The designsystem as a whole is called *Builders Core*, it contains [tone of voice](https://www.gjensidige.builders/onboarding/brand/tone-of-voice), components (internal use only, same as source code), and Figma files (internal only).